### PR TITLE
Revert "Bump maven-plugin-api from 3.6.2 to 3.8.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.java>8</version.java>
-        <maven.version>3.8.4</maven.version>
+        <maven.version>3.6.2</maven.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/
         </nexus.snapshot.repository>


### PR DESCRIPTION
This reverts commit 2b0dbfda817c14a917f8126f83b7d1beab27a151.

Bumping up the version had too many ripple effects in downstream projects. Therefore, it was decided to roll back the Maven version to the old value.