### PR TITLE
General improvement & impl. issue #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ This plugin scans the XML file for flaky tests results and then generates additi
 
 ## How can I configure this plugin?
 
-There are two configuration options:
+There are three configuration options:
 * `reportDir` (defaultValue `${project.build.directory}/surefire-reports`) - this is the directory that will be scanned for XML report file. It is also the directory to which new XML files will be written
 * `failBuild` (defaultValue `true`) - flag to make the plugin fail the build if flaky test were discovered	
+* `skipFlakyTestExtractor` (defaultValue `false`) - flag to skip this plugin
 
 ## What are known shortcomings?
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,6 @@
 
     <name>flaky-test-extractor Maven Plugin</name>
 
-    <prerequisites>
-        <maven>${maven.version}</maven>
-    </prerequisites>
-
     <parent>
         <groupId>org.camunda</groupId>
         <artifactId>camunda-release-parent</artifactId>
@@ -180,6 +176,9 @@
                 <configuration>
                     <rules>
                         <dependencyConvergence />
+                        <requireMavenVersion>
+                            <version>${maven.version}</version>
+                        </requireMavenVersion>
                     </rules>
                 </configuration>
                 <executions>

--- a/src/main/java/io/zeebe/flakytestextractor/FlakyTestExtractorPlugin.java
+++ b/src/main/java/io/zeebe/flakytestextractor/FlakyTestExtractorPlugin.java
@@ -22,10 +22,18 @@ public class FlakyTestExtractorPlugin extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.directory}/surefire-reports", property = "reportDir")
 	protected File reportDir;
 
-	@Parameter(defaultValue = "true", property = "failBuild", required = false)
+	@Parameter(defaultValue = "true", property = "failBuild")
 	protected boolean failBuild = true;
 
+	@Parameter(defaultValue = "false", property = "skipFlakyTestExtractor")
+	protected boolean skip = false;
+
 	public void execute() throws MojoFailureException {
+		if(skip){
+			getLog().info("extract-flaky-tests Plugin skipped");
+			return;
+		}
+
 		getLog().info("FlakyTestExtractorPlugin - starting");
 		getLog().info("reportDir: " + reportDir.getAbsolutePath());
 		getLog().info("failBuild: " + failBuild);

--- a/src/main/java/io/zeebe/flakytestextractor/XmlReporterWriter.java
+++ b/src/main/java/io/zeebe/flakytestextractor/XmlReporterWriter.java
@@ -86,7 +86,7 @@ public class XmlReporterWriter {
         ppw.addAttribute("xsi:noNamespaceSchemaLocation", xsdSchemaLocation);
         ppw.addAttribute("version", xsdVersion);
 
-        final String reportName = testSuite.getName();
+        final String reportName = testSuite.getFullClassName();
         ppw.addAttribute("name", reportName == null ? "" : extraEscapeAttribute(reportName));
         ppw.addAttribute("time", String.valueOf(testSuite.getTimeElapsed()));
         ppw.addAttribute("tests", String.valueOf(testSuite.getNumberOfTests()));
@@ -100,7 +100,7 @@ public class XmlReporterWriter {
         final String name = testCase.getName();
         ppw.addAttribute("name", name == null ? "" : extraEscapeAttribute(name));
 
-        final String className = testCase.getClassName();
+        final String className = testCase.getFullClassName();
         if (className != null) {
             ppw.addAttribute("classname", extraEscapeAttribute(className));
         }

--- a/src/test/java/io/zeebe/flakytestextractor/FlakyTestExtractorPluginTest.java
+++ b/src/test/java/io/zeebe/flakytestextractor/FlakyTestExtractorPluginTest.java
@@ -71,6 +71,18 @@ public class FlakyTestExtractorPluginTest {
 		}).doesNotThrowAnyException();
 	}
 
+	@Test
+	public void testExecuteWithSkipped() {
+		FlakyTestExtractorPlugin sut = new FlakyTestExtractorPlugin();
+		sut.reportDir = tempFolder.getRoot();
+		sut.skip = true;
+
+		assertThatCode(sut::execute).doesNotThrowAnyException();
+
+		File[] createdFiles = tempFolder.getRoot().listFiles(file -> file.getName().endsWith("-FLAKY.xml"));
+		assertThat(createdFiles).isEmpty();
+	}
+
 	private void inspectFlakyErrorReport(File flakyErrorReport)
 			throws ParserConfigurationException, SAXException, IOException, FileNotFoundException {
 


### PR DESCRIPTION
**Changes:** 

- [move from specific maven version to minimal required version](https://github.com/zeebe-io/flaky-test-extractor-maven-plugin/commit/bd1606fa83d238355c29d2fe6c26d0cf50e9507d)
Before: You can only use this plugin with the maven version 3.6.2. 
Now: The plugin can be used by all maven versions newer or equal to 3.6.2.
- [use fullClassName in summary file](https://github.com/zeebe-io/flaky-test-extractor-maven-plugin/commit/4470e69c828823a06992be1836e1020f4fc642f6)
Provides more detailed information about the flaky test. 
- [add skip feature](https://github.com/zeebe-io/flaky-test-extractor-maven-plugin/commit/8c13769425ac8862a38246d93400df7c33384fbf)
Enables the user to skip the plugin. Was requested in [issue #22 ](https://github.com/zeebe-io/flaky-test-extractor-maven-plugin/issues/22).