### PR TITLE
fix(ci): add git safe directory for release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,7 @@ pipeline {
               sh 'gpg -q --allow-secret-key-import --import --no-tty --batch --yes ${GPG_SEC_KEY}'
               sh 'git config --global user.email "ci@camunda.com"'
               sh 'git config --global user.name "${GITHUB_TOKEN_USR}"'
+              sh 'git config --global --add safe.directory "${PWD}"'
               sh 'mvn -B -s $MAVEN_SETTINGS_XML -DskipTests source:jar javadoc:jar release:prepare release:perform -Prelease'
           }
         }


### PR DESCRIPTION
This addresses a new safety check that currently leads to a failing release.

Same as https://github.com/zeebe-io/zeebe-cluster-testbench/pull/772