### PR TITLE
chore: remove bors.toml config file

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-  "continuous-integration/jenkins/branch"
-]
-
-required_approvals = 1
-
-delete_merged_branches = true
-
-cut_body_after = "# Pull Request Checklist"


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/633 and the removal of Bors instances.

This PR removes the `bors.toml` file, which is no longer used.
