### PR TITLE
ci: upgrade camunda-release-parent to 4.0.0 and switch to Central Portal deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-release-parent</artifactId>
-    <version>3.9.1</version>
+    <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR upgrades the `camunda-release-parent `POM to version 4.0.0 and switches to the new `central-sonatype-publish` profile. This is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.

To ensure a smooth transition, I’ve highlighted the changes related to plugin execution (for one of the modules) to validate them and make sure no unexpected modifications are introduced.

Effective changes:

TL;DR ✅ 
- The `central-sonatype-publish` profile is now the default and is appended to the value of `arguments` property of the `maven-release-plugin`.
- The `nexus-staging-maven-plugin` has been updated to a newer patch version.
- A new `id:central-deploy` execution of the `central-publishing-maven-plugin` is configured, replacing the previous `id:central-deploy` execution from the `nexus-staging-maven-plugin`.
- The `nexusUrl` of the `id:default-deploy` execution from the `nexus-staging-maven-plugin` now points to the correct URL but is skipped because `skipStaging` is set to true.

```diff
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
 <build>
   <pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+      </plugin>
+      <plugin>
         <groupId>io.zeebe</groupId>
         <artifactId>flaky-test-extractor-maven-plugin</artifactId>
         <version>2.1.1</version>
       </plugin>
       <plugin>
@@ -78,10 +83,14 @@
             </manifest>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.5.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-gpg-plugin</artifactId>
@@ -118,11 +127,11 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
           <mavenExecutorId>forked-path</mavenExecutorId>
           <useReleaseProfile>false</useReleaseProfile>
-          <arguments>${arguments} -Psonatype-oss-release</arguments>
+          <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.6.0</version>
@@ -155,11 +164,11 @@
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
       </plugin>
       <plugin>
         <groupId>eu.stamp-project</groupId>
         <artifactId>pitmp-maven-plugin</artifactId>
         <version>1.3.7</version>
@@ -178,10 +187,39 @@
         <version>2.43.0</version>
       </plugin>
     </plugins>
   </pluginManagement>
   <plugins>
+    <plugin>
+      <groupId>org.sonatype.central</groupId>
+      <artifactId>central-publishing-maven-plugin</artifactId>
+      <version>0.7.0</version>
+      <extensions>true</extensions>
+      <executions>
+        <execution>
+          <id>central-deploy</id>
+          <phase>deploy</phase>
+          <goals>
+            <goal>publish</goal>
+          </goals>
+          <configuration>
+            <autoPublish>false</autoPublish>
+            <deploymentName>io.zeebe:zeebe-cluster-testbench-core:3.0.5-SNAPSHOT</deploymentName>
+            <failOnBuildFailure>true</failOnBuildFailure>
+            <publishingServerId>central</publishingServerId>
+            <skipPublishing>false</skipPublishing>
+          </configuration>
+        </execution>
+      </executions>
+      <configuration>
+        <autoPublish>false</autoPublish>
+        <deploymentName>io.zeebe:zeebe-cluster-testbench-core:3.0.5-SNAPSHOT</deploymentName>
+        <failOnBuildFailure>true</failOnBuildFailure>
+        <publishingServerId>central</publishingServerId>
+        <skipPublishing>false</skipPublishing>
+      </configuration>
+    </plugin>
     <plugin>
       <groupId>io.zeebe</groupId>
       <artifactId>flaky-test-extractor-maven-plugin</artifactId>
       <version>2.1.1</version>
       <executions>
@@ -524,11 +562,11 @@
       </executions>
     </plugin>
     <plugin>
       <groupId>org.sonatype.plugins</groupId>
       <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>1.6.8</version>
+      <version>1.6.13</version>
       <extensions>true</extensions>
       <executions>
         <execution>
           <id>default-deploy</id>
           <phase>deploy</phase>
@@ -536,28 +574,12 @@
             <goal>deploy</goal>
           </goals>
           <configuration>
             <detectBuildFailures>true</detectBuildFailures>
             <serverId>camunda-nexus</serverId>
-            <nexusUrl>https://app.camunda.com/nexus</nexusUrl>
+            <nexusUrl>https://artifacts.camunda.com/artifactory</nexusUrl>
             <skipStaging>true</skipStaging>
-            <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
-          </configuration>
-        </execution>
-        <execution>
-          <id>central-deploy</id>
-          <phase>deploy</phase>
-          <goals>
-            <goal>deploy</goal>
-          </goals>
-          <configuration>
-            <detectBuildFailures>true</detectBuildFailures>
-            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-            <serverId>central</serverId>
-            <nexusUrl>https://oss.sonatype.org</nexusUrl>
-            <skipStaging>false</skipStaging>
             <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
           </configuration>
         </execution>
       </executions>
     </plugin>
```